### PR TITLE
fix: remove hardcoded docker in artifact registry image path

### DIFF
--- a/modules/artifact-registry/outputs.tf
+++ b/modules/artifact-registry/outputs.tf
@@ -22,7 +22,7 @@ output "id" {
 output "image_path" {
   description = "Repository path for images."
   value = join("/", [
-    "${var.location}-docker.pkg.dev",
+    "${var.location}-${local.format_string}.pkg.dev",
     var.project_id,
     var.name
   ])


### PR DESCRIPTION
<!-- Put a description of what this PR is for here -->

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [ ] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [ ] Ran `terraform fmt` on all modified files
- [ ] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [ ] Made sure all relevant tests pass
